### PR TITLE
fix: handle empty files #3

### DIFF
--- a/src/convert/sigma.rs
+++ b/src/convert/sigma.rs
@@ -361,6 +361,11 @@ pub fn load(rule: &Path) -> Result<Vec<Yaml>> {
         })
         .collect();
 
+    // Silently error if we found no sigma rules.
+    if sigma.is_empty() {
+        return Ok(vec![]);
+    }
+
     let main = sigma.remove(0);
     let base = match main.as_base() {
         Some(base) => base,


### PR DESCRIPTION
Loading empty yaml files into chainsaw would cause it to panic due to a
stupid assumption. This has now been taken care of.