### PR TITLE
Correctly convert Sigma's Rule Collection rules

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -12,6 +12,10 @@ pub struct CheckOpts {
     /// Required when using the --rule/-r flag
     #[structopt(short = "m", long = "mapping")]
     pub mapping_path: PathBuf,
+
+    /// Print verbose
+    #[structopt(short = "v", long = "verbose")]
+    pub verbose: bool,
 }
 
 pub fn run_check(opt: CheckOpts) -> Result<String> {
@@ -27,6 +31,6 @@ pub fn run_check(opt: CheckOpts) -> Result<String> {
         }
     }
     cs_println!("[+] Validating supplied detection rules...\n\r");
-    load_detection_rules(&opt.rules_path, true, &mapping_file)?;
+    load_detection_rules(&opt.rules_path, true, &mapping_file, opt.verbose)?;
     Ok("".to_string())
 }

--- a/src/convert/sigma.rs
+++ b/src/convert/sigma.rs
@@ -179,10 +179,10 @@ fn parse_identifier(value: &Yaml, modifiers: &HashSet<String>) -> Result<Yaml> {
 
 fn prepare(detection: Detection, extra: Option<Detection>) -> Result<Detection> {
     let mut detection = detection;
-    let condition = detection
-        .condition
-        .clone()
-        .or(extra.as_ref().and_then(|e| e.condition.clone()));
+    let condition = extra
+        .as_ref()
+        .and_then(|e| e.condition.clone())
+        .or(detection.condition.clone());
     if let Some(c) = &condition {
         if c == "all of them" {
             let mut scratch = Sequence::new();

--- a/src/convert/sigma.rs
+++ b/src/convert/sigma.rs
@@ -390,6 +390,7 @@ pub fn load(rule: &Path) -> Result<Vec<Yaml>> {
     // https://github.com/SigmaHQ/sigma/wiki/Specification#rule-collections
     // TODO: This is a minimal implementation which supports most of the styles found in the
     // Windows rules. We can do a more complete one when required.
+    let mut single = false;
     if main.header.and_then(|m| m.action).is_some() {
         for sigma in sigma.into_iter() {
             if let Some(extension) = sigma.detection {
@@ -406,9 +407,15 @@ pub fn load(rule: &Path) -> Result<Vec<Yaml>> {
                     rule.insert(k, v);
                 }
                 rules.push(rule.into());
+            } else {
+                single = true;
             }
         }
     } else {
+        single = true;
+    }
+
+    if single {
         let mut rule = base;
         if let Some(detection) = main.detection {
             let detection = prepare(detection, None)?;

--- a/src/hunt/mod.rs
+++ b/src/hunt/mod.rs
@@ -248,6 +248,7 @@ pub fn run_hunt(opt: HuntOpts) -> Result<String> {
                 rules,
                 false,
                 mapping_file.as_ref().expect("No mapping file"),
+                false,
             )?)
         }
         None => {
@@ -686,6 +687,7 @@ pub fn load_detection_rules(
     path: &Path,
     check: bool,
     mapping: &Mapping,
+    verbose: bool,
 ) -> Result<Vec<ChainsawRule>> {
     let mut count = 0;
     let mut failed = 0;
@@ -725,6 +727,14 @@ pub fn load_detection_rules(
                                 continue;
                             }
                         };
+                        if verbose {
+                            for rule in &rules {
+                                println!(
+                                    "{}",
+                                    serde_yaml::to_string(&rule).expect("could not serialise")
+                                );
+                            }
+                        }
                         for file in rules {
                             let rule: ChainsawRule = match serde_yaml::from_value(file) {
                                 Ok(e) => e,

--- a/src/hunt/modules.rs
+++ b/src/hunt/modules.rs
@@ -212,7 +212,7 @@ pub fn detect_tau_matches(
                 };
                 doc[k] = json!(h);
             }
-            doc["EventID"] = json!(event_id.to_string());
+            doc["EventID"] = json!(event_id);
 
             // Find the context_field and extract it's value from the event
             command_line = match fields.table_headers.get("context_field") {


### PR DESCRIPTION
We parsed these very incorrectly, this PR should rectify that (#37). In addition as this is now fixed I have re-reverted the string casting issue to fix #19.

~~This change has increased the number of detections with the default data set, so this will need double checking.~~

Done a diff and the only difference is the addition of some rules that were failing due to the EventID string issue. So I think this is good to go.