### PR TITLE
feat: add in output command as requested for #60

### DIFF
--- a/src/convert/sigma.rs
+++ b/src/convert/sigma.rs
@@ -71,7 +71,7 @@ impl Sigma {
             tau.insert(
                 "authors".into(),
                 author
-                    .split(",")
+                    .split(',')
                     .map(|a| a.trim())
                     .collect::<Vec<_>>()
                     .into(),

--- a/src/hunt/mod.rs
+++ b/src/hunt/mod.rs
@@ -52,7 +52,7 @@ pub struct HuntOpts {
     pub lateral_all: bool,
 
     /// Save hunt output to individual CSV files in the specified directory
-    #[structopt(long = "csv", group = "output")]
+    #[structopt(long = "csv", group = "format")]
     pub csv: Option<PathBuf>,
 
     /// Show rule author information in table output
@@ -64,7 +64,7 @@ pub struct HuntOpts {
     pub full_output: bool,
 
     /// Save the full event log and associated detections to disk in a JSON format to the specified path
-    #[structopt(short, long = "json", group = "output")]
+    #[structopt(short, long = "json", group = "format")]
     pub json: bool,
 
     /// Do not use inbuilt detection logic, only use the specified rules for detection
@@ -82,6 +82,10 @@ pub struct HuntOpts {
     /// End date for including events (UTC). Anything newer than this is dropped. Format: YYYY-MM-DDTHH:MM:SS. Example: 2019-11-17T17:55:11
     #[structopt(long = "end-date")]
     pub end_date: Option<String>,
+
+    /// File to write output to, this is ignored by --csv
+    #[structopt(long = "output")]
+    pub output: Option<PathBuf>,
 }
 
 #[derive(Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use std::fs::File;
 
 // TODO: Clean this, we have crudely split into a lib for testing purposes, this needs refinement.
@@ -55,7 +56,11 @@ fn main() {
                     let file = match File::create(path) {
                         Ok(f) => f,
                         Err(e) => {
-                            panic!("could not create file - {}", e);
+                            return exit_chainsaw(Err(anyhow::anyhow!(
+                                "Unable to write to specified output file - {} - {}",
+                                path.display(),
+                                e
+                            )));
                         }
                     };
                     Some(file)
@@ -88,7 +93,11 @@ fn main() {
                     let file = match File::create(path) {
                         Ok(f) => f,
                         Err(e) => {
-                            panic!("could not create file - {}", e);
+                            return exit_chainsaw(Err(anyhow::anyhow!(
+                                "Unable to write to specified output file - {} - {}",
+                                path.display(),
+                                e
+                            )));
                         }
                     };
                     Some(file)
@@ -111,6 +120,10 @@ fn main() {
         Chainsaw::Hunt(args) => hunt::run_hunt(args),
         Chainsaw::Check(args) => check::run_check(args),
     };
+    exit_chainsaw(result);
+}
+
+fn exit_chainsaw(result: Result<String>) {
     // Handle successful/failed status messages returned by chainsaw
     std::process::exit(match result {
         Ok(m) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::fs::File;
+
 // TODO: Clean this, we have crudely split into a lib for testing purposes, this needs refinement.
 use chainsaw::*;
 
@@ -48,27 +50,57 @@ fn main() {
     // Load up the writer
     let writer = match &opt.cmd {
         Chainsaw::Hunt(args) => {
+            let output = match &args.output {
+                Some(path) => {
+                    let file = match File::create(path) {
+                        Ok(f) => f,
+                        Err(e) => {
+                            panic!("could not create file - {}", e);
+                        }
+                    };
+                    Some(file)
+                }
+                None => None,
+            };
             if args.json {
                 write::Writer {
                     format: write::Format::Json,
+                    output,
                     quiet: args.quiet,
                 }
             } else if let Some(dir) = &args.csv {
                 write::Writer {
                     format: write::Format::Csv(dir.clone()),
+                    output,
                     quiet: args.quiet,
                 }
             } else {
                 write::Writer {
                     format: write::Format::Std,
+                    output,
                     quiet: args.quiet,
                 }
             }
         }
-        Chainsaw::Search(args) => write::Writer {
-            format: write::Format::Std,
-            quiet: args.quiet,
-        },
+        Chainsaw::Search(args) => {
+            let output = match &args.output {
+                Some(path) => {
+                    let file = match File::create(path) {
+                        Ok(f) => f,
+                        Err(e) => {
+                            panic!("could not create file - {}", e);
+                        }
+                    };
+                    Some(file)
+                }
+                None => None,
+            };
+            write::Writer {
+                format: write::Format::Std,
+                output,
+                quiet: args.quiet,
+            }
+        }
         _ => write::Writer::default(),
     };
     write::set_writer(writer).unwrap();

--- a/src/search.rs
+++ b/src/search.rs
@@ -55,7 +55,7 @@ pub struct SearchOpts {
     #[structopt(long = "end-date")]
     pub end_date: Option<String>,
 
-    /// File to write output to
+    /// Output with be saved to the specified file path, this is ignored by --csv
     #[structopt(long = "output")]
     pub output: Option<PathBuf>,
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -54,6 +54,10 @@ pub struct SearchOpts {
     /// End date for including events (UTC). Anything newer than this is dropped. Format: YYYY-MM-DDTHH:MM:SS. Example: 2019-11-17T17:55:11
     #[structopt(long = "end-date")]
     pub end_date: Option<String>,
+
+    /// File to write output to
+    #[structopt(long = "output")]
+    pub output: Option<PathBuf>,
 }
 
 pub fn run_search(opt: SearchOpts) -> Result<String> {

--- a/src/write.rs
+++ b/src/write.rs
@@ -99,7 +99,7 @@ macro_rules! cs_print_yaml {
             match $crate::write::WRITER.output.as_ref() {
                 Some(mut f) => {
                     $crate::serde_yaml::to_writer(f, $value)?;
-                    f.write(b"\n")?;
+                    f.write_all(b"\n")?;
                     f.flush()
                 }
                 None => {
@@ -129,8 +129,8 @@ macro_rules! cs_greenln {
         unsafe {
             match $crate::write::WRITER.output.as_ref() {
                 Some(mut f) => {
-                    f.write(format!($($arg)*).as_bytes()).expect("could not write to file");
-                    f.write(b"\n").expect("could not write to file");
+                    f.write_all(format!($($arg)*).as_bytes()).expect("could not write to file");
+                    f.write_all(b"\n").expect("could not write to file");
                 }
                 None => {
                     colour::unnamed::write(Some(colour::unnamed::Colour::Green), &format!($($arg)*), true);


### PR DESCRIPTION
Adds the changes required so that `--output` can be used in chainsaw as it seems some times pipe redirection is not viable. This probably needs a bit of testing but as always we lack the time and people (well that is my excuse anyways) :)