### PR TITLE
fix: use evtx extension by default for loading event logs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -257,7 +257,8 @@ fn run() -> Result<()> {
             };
 
             cs_eprintln!(
-                "[+] Loading event logs from: {}",
+                "[+] Loading event logs (.{}) from: {}",
+                if let Some(x) = &extension { x } else { "evtx" },
                 path.iter()
                     .map(|p| p.display().to_string())
                     .collect::<Vec<_>>()
@@ -346,7 +347,13 @@ fn run() -> Result<()> {
             let mut files = vec![];
             let mut size = ByteSize::mb(0);
             for path in &path {
-                let res = get_files(path, &extension, skip_errors)?;
+                let res;
+                // When loading event logs, if no extension is set then enforce evtx extension
+                if extension.is_some() {
+                    res = get_files(path, &extension, skip_errors)?;
+                } else {
+                    res = get_files(path, &Some("evtx".to_string()), skip_errors)?;
+                }
                 for i in &res {
                     size += i.metadata()?.len();
                 }
@@ -488,10 +495,26 @@ fn run() -> Result<()> {
                     std::env::current_dir().expect("could not get current working directory"),
                 );
             }
+
+            cs_eprintln!(
+                "[+] Loading event logs (.{}) from: {}",
+                if let Some(x) = &extension { x } else { "evtx" },
+                paths
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
             let mut files = vec![];
             let mut size = ByteSize::mb(0);
             for path in &paths {
-                let res = get_files(path, &extension, skip_errors)?;
+                let res;
+                // When loading event logs, if no extension is set then enforce evtx extension
+                if extension.is_some() {
+                    res = get_files(path, &extension, skip_errors)?;
+                } else {
+                    res = get_files(path, &Some("evtx".to_string()), skip_errors)?;
+                }
                 for i in &res {
                     size += i.metadata()?.len();
                 }


### PR DESCRIPTION
Fix logic when loading event logs which resulted in all files in the specified event log path being loaded regardless of extension:

**Old Logic:**
```
-> % ls /tmp/example
foo.txt
james@jamess-MBP-2 [00:31:51] [~/Desktop/chainsaw/target/release] [feat/search_by_event_id *]
-> % ./chainsaw hunt ~/Desktop/chainsaw/sigma_rules /tmp/example -m ../../mappings/sigma-event-logs.yml

 ██████╗██╗  ██╗ █████╗ ██╗███╗   ██╗███████╗ █████╗ ██╗    ██╗
██╔════╝██║  ██║██╔══██╗██║████╗  ██║██╔════╝██╔══██╗██║    ██║
██║     ███████║███████║██║██╔██╗ ██║███████╗███████║██║ █╗ ██║
██║     ██╔══██║██╔══██║██║██║╚██╗██║╚════██║██╔══██║██║███╗██║
╚██████╗██║  ██║██║  ██║██║██║ ╚████║███████║██║  ██║╚███╔███╔╝
 ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝
    By F-Secure Countercept (@FranticTyping, @AlexKornitzer)

[+] Loading event logs from: ["/tmp/example"]
[+] Loading detection rules from: ["/Users/james/Desktop/chainsaw/sigma_rules"]
[+] Loaded 1018 detection rules (348 not loaded)
[+] Loaded 1 EVTX files (0 B)
```
TXT file is loaded despite not being an event log.

**New Logic:**
```
james@jamess-MBP-2 [00:33:03] [/tmp/fix/chainsaw/target/release] [fix/default_evtx_extension]
-> % ./chainsaw hunt ~/Desktop/chainsaw/sigma_rules /tmp/example -m ../../mappings/sigma-event-logs.yml

 ██████╗██╗  ██╗ █████╗ ██╗███╗   ██╗███████╗ █████╗ ██╗    ██╗
██╔════╝██║  ██║██╔══██╗██║████╗  ██║██╔════╝██╔══██╗██║    ██║
██║     ███████║███████║██║██╔██╗ ██║███████╗███████║██║ █╗ ██║
██║     ██╔══██║██╔══██║██║██║╚██╗██║╚════██║██╔══██║██║███╗██║
╚██████╗██║  ██║██║  ██║██║██║ ╚████║███████║██║  ██║╚███╔███╔╝
 ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝
    By F-Secure Countercept (@FranticTyping, @AlexKornitzer)

[+] Loading event logs (.evtx) from: /tmp/example
[+] Loading detection rules from: /Users/james/Desktop/chainsaw/sigma_rules
[+] Loaded 1018 detection rules (337 not loaded)
[x] No event logs were found in the provided paths
james@jamess-MBP-2 [00:33:07] [/tmp/fix/chainsaw/target/release] [fix/default_evtx_extension]
-> % ./chainsaw hunt ~/Desktop/chainsaw/sigma_rules /tmp/example -m ../../mappings/sigma-event-logs.yml --extension "txt"

 ██████╗██╗  ██╗ █████╗ ██╗███╗   ██╗███████╗ █████╗ ██╗    ██╗
██╔════╝██║  ██║██╔══██╗██║████╗  ██║██╔════╝██╔══██╗██║    ██║
██║     ███████║███████║██║██╔██╗ ██║███████╗███████║██║ █╗ ██║
██║     ██╔══██║██╔══██║██║██║╚██╗██║╚════██║██╔══██║██║███╗██║
╚██████╗██║  ██║██║  ██║██║██║ ╚████║███████║██║  ██║╚███╔███╔╝
 ╚═════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═╝╚═╝  ╚═══╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝
    By F-Secure Countercept (@FranticTyping, @AlexKornitzer)

[+] Loading event logs (.txt) from: /tmp/example
[+] Loading detection rules from: /Users/james/Desktop/chainsaw/sigma_rules
[+] Loaded 1018 detection rules (337 not loaded)
[+] Loaded 1 EVTX files (0 B)
[+] Hunting: [========================================] 1/1
[+] 0 Detections found on 0 documents
```
